### PR TITLE
Fix compile error in View.cpp

### DIFF
--- a/src/View.cpp
+++ b/src/View.cpp
@@ -177,7 +177,7 @@ namespace genfile {
 
 			// get file size
 			{
-				std::ios::streampos origin = m_stream->tellg() ;
+                               std::streampos origin = m_stream->tellg() ;
 				m_stream->seekg( 0, std::ios::end ) ;
 				m_file_metadata.size = m_stream->tellg() - origin ;
 				m_stream->seekg( 0, std::ios::beg ) ;


### PR DESCRIPTION
## Summary
- fix build failure due to std::ios::streampos not found
- use std::streampos when computing file size in View::setup

## Testing
- `./waf`
- `./build/test/unit/test_bgen`

------
https://chatgpt.com/codex/tasks/task_e_6888c9762f448327a024266746e56e4f