### PR TITLE
Fix compiler warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+Coding Instructions for the bgen repository:
+
+Build:
+  ./waf configure
+  ./waf
+
+Testing:
+  ./build/test/unit/test_bgen
+  ./build/apps/bgenix -g example/example.16bits.bgen -list
+
+Please run these steps after code changes to ensure everything compiles and tests pass.

--- a/apps/bgenix.cpp
+++ b/apps/bgenix.cpp
@@ -919,7 +919,7 @@ private:
 			case 4: dps = 3; break ;
 			case 8: dps = 4; break ;
 		}
-		int const valueSize = 3 + 3 + 3*(dps+((dps>0)?2:1)) ;
+               std::size_t const valueSize = 3 + 3 + 3*(dps + ((dps>0)?2:1)) ;
 		std::size_t const numberOfDistinctProbs = 1 << bits ;
 		uint16_t const maxProb = numberOfDistinctProbs - 1 ;
 
@@ -949,7 +949,7 @@ private:
 				std::size_t storageIndex = key * valueSize ;
 				formatter << gt << ":" << p0 << "," << p1 << "," << p2 ; 
 				std::string const value = formatter.str() ;
-				assert( value.size() == valueSize ) ;
+                               assert( value.size() == valueSize ) ;
 				std::copy( value.begin(), value.end(), &storage[0] + storageIndex ) ;
 			}
 		}

--- a/genfile/include/genfile/bgen/bgen.hpp
+++ b/genfile/include/genfile/bgen/bgen.hpp
@@ -1258,12 +1258,12 @@ namespace genfile {
 							// Consume values and interpret them.
 							double sum = 0.0 ;
 							uint32_t reportedValueCount = 0 ;
-							if( !valueConsumer.check( ploidy * (pack.numberOfAlleles-1) )) {
-								throw BGenError() ;
-							}
-							for( uint32_t hap = 0; hap < ploidy; ++hap ) {
-								for( uint32_t allele = 0; allele < (pack.numberOfAlleles-1); ++allele ) {
-									double const value = valueConsumer.next() ;
+                                                       if( !valueConsumer.check( ploidy * ( static_cast< uint32_t >( pack.numberOfAlleles ) - 1u ) )) {
+                                                               throw BGenError() ;
+                                                       }
+                                                       for( uint32_t hap = 0; hap < ploidy; ++hap ) {
+                                                               for( uint32_t allele = 0; allele < static_cast< uint32_t >( pack.numberOfAlleles ) - 1u; ++allele ) {
+                                                                       double const value = valueConsumer.next() ;
 									switch( sample_status ) {
 										case eIgnore: break ;
 										case eSetAsMissing:

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -209,8 +209,8 @@ namespace genfile {
 			// read data up to first data block.
 			m_postheader_data.resize( m_offset+4 - m_stream->tellg() ) ;
 			m_stream->read( reinterpret_cast< char* >( &m_postheader_data[0] ), m_postheader_data.size() ) ;
-			if( m_stream->gcount() != m_postheader_data.size() ) {
-				throw std::invalid_argument(
+                       if( static_cast< std::size_t >( m_stream->gcount() ) != m_postheader_data.size() ) {
+                               throw std::invalid_argument(
 					(
 						boost::format(
 							"BGEN file (\"%s\") appears malformed - offset specifies more bytes (%d) than are in the file."

--- a/test/unit/test_variant_data_block.cpp
+++ b/test/unit/test_variant_data_block.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 				writer.set_number_of_entries( 3, 3, genfile::ePerUnorderedGenotype, genfile::eProbability ) ;
 				for( std::size_t k = 0; k < 3; ++k ) {
 					if( k == g ) {
-						REQUIRE_THROWS_AS( writer.set_value( k, 1.0 + error + 2 * epsilon ), genfile::bgen::BGenError ) ;
+                                               REQUIRE_THROWS_AS( writer.set_value( k, 1.0 + error + 2 * epsilon ), genfile::bgen::BGenError const& ) ;
 						break ;
 					} else {
 						REQUIRE_NOTHROW( writer.set_value( k, 0 ) ) ;
@@ -105,7 +105,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 						REQUIRE_NOTHROW( writer.set_value( k, v ) ) ;
 					} else {
 						// last value will throw.
-						REQUIRE_THROWS_AS(  writer.set_value( k, v ), genfile::bgen::BGenError ) ;
+                                               REQUIRE_THROWS_AS(  writer.set_value( k, v ), genfile::bgen::BGenError const& ) ;
 					}
 				}
 			}
@@ -121,7 +121,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 						REQUIRE_NOTHROW( writer.set_value( k, v ) ) ;
 					} else {
 						// last value will throw
-						REQUIRE_THROWS_AS( writer.set_value( k, v ), genfile::bgen::BGenError ) ;
+                                               REQUIRE_THROWS_AS( writer.set_value( k, v ), genfile::bgen::BGenError const& ) ;
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- fix sign-compare warnings in probability data parsing
- avoid sign mismatch in View
- use size_t for `valueSize`
- catch `BGenError` by reference
- document build/test steps in AGENTS.md

## Testing
- `./waf configure`
- `./waf`
- `./build/test/unit/test_bgen`
- `./build/apps/bgenix -g example/example.16bits.bgen -list`


------
https://chatgpt.com/codex/tasks/task_e_6888ce12e88c832786dcaec3bab9021f