### PR TITLE
Add CI workflow and python package skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,6 @@ jobs:
 
       - name: Publish to PyPI
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
   push:
     branches: [ main ]
+    tags: [ 'v*' ]
 
 jobs:
   build:
@@ -23,3 +24,9 @@ jobs:
         run: |
           pip install build
           python -m build --wheel
+
+      - name: Publish to PyPI
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3 python3-pip g++ make
+      - name: Build with waf
+        run: |
+          ./waf configure
+          ./waf
+      - name: Run unit tests
+        run: ./build/test/unit/test_bgen
+      - name: Build wheel
+        run: |
+          pip install build
+          python -m build --wheel

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .waf-1.8.13*
 .waf-2.0.6*
 build
+bgenlib/bin
+*.egg-info
+

--- a/README.md
+++ b/README.md
@@ -197,6 +197,22 @@ Continuous integration is provided via a GitHub Actions workflow
 (`.github/workflows/ci.yml`) which builds the project, runs the unit tests and
 builds a wheel.  Tagged releases can be uploaded to PyPI using this workflow.
 
+### Publishing to PyPI
+
+1. [Create an account](https://pypi.org/account/register/) on PyPI and
+   generate an API token.
+2. In your GitHub repository settings add the token as a secret called
+   `PYPI_API_TOKEN`.
+3. Tag a release, for example:
+
+   ```bash
+   git tag -a v1.2.3 -m "Release v1.2.3"
+   git push origin v1.2.3
+   ```
+
+When a tag beginning with `v` is pushed, the CI workflow will build the
+package and publish it to PyPI using the provided token.
+
 ### More information
 
 See the [source code](/dir?ci=release), 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,23 @@ we therefore recommend cloning the `release` branch. Code development takes plac
 branch and/or in feature branches branched from the `trunk` branch. The command given above
 downloads the release branch, which is what most people will want.
 
+### Python package and CI
+
+This repository contains a lightweight Python wrapper called `bgenlib`.  The
+package compiles the `bgenix` tool during installation and exposes it as a
+console script.  You can install it directly from PyPI with:
+
+```
+pip install bgenlib
+```
+
+After installation `bgenix` will be available on your `PATH` and can be used as
+normal.
+
+Continuous integration is provided via a GitHub Actions workflow
+(`.github/workflows/ci.yml`) which builds the project, runs the unit tests and
+builds a wheel.  Tagged releases can be uploaded to PyPI using this workflow.
+
 ### More information
 
 See the [source code](/dir?ci=release), 

--- a/bgenlib/__init__.py
+++ b/bgenlib/__init__.py
@@ -1,0 +1,1 @@
+# BGEN Python wrapper

--- a/bgenlib/runner.py
+++ b/bgenlib/runner.py
@@ -1,0 +1,7 @@
+import os
+import sys
+from pathlib import Path
+
+def run_bgenix():
+    exe = Path(__file__).resolve().parent / 'bin' / 'bgenix'
+    os.execv(str(exe), ['bgenix'] + sys.argv[1:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+from setuptools import setup
+from setuptools.command.build_ext import build_ext
+import subprocess
+
+class BuildWaf(build_ext):
+    def run(self):
+        subprocess.check_call(['./waf', 'configure'])
+        subprocess.check_call(['./waf'])
+        bin_dir = Path('bgenlib/bin')
+        bin_dir.mkdir(parents=True, exist_ok=True)
+        (Path('build') / 'apps' / 'bgenix').rename(bin_dir / 'bgenix')
+        super().run()
+
+setup(
+    name='bgenlib',
+    version='1.1.7',
+    description='BGEN reference implementation packaged for Python',
+    packages=['bgenlib'],
+    package_data={'bgenlib': ['bin/bgenix']},
+    cmdclass={'build_ext': BuildWaf},
+    entry_points={'console_scripts': ['bgenix=bgenlib.runner:run_bgenix']},
+)


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and test
- provide a minimal Python package wrapping the `bgenix` tool
- ignore packaging artifacts
- document PyPI package and CI pipeline in README
- fix package install step in workflow

## Testing
- `./waf configure`
- `./waf`
- `./build/test/unit/test_bgen`
- ❌ `pip install build` *(fails: Cannot connect to proxy)*
- ❌ `python -m build --wheel` *(missing `build` module)*

------
https://chatgpt.com/codex/tasks/task_e_6888ccbfd28083278da48d4e8076256e