### PR TITLE
Clear the compiler warnings in BGEN's own sources

### DIFF
--- a/3rd_party/boost_1_55_0/wscript
+++ b/3rd_party/boost_1_55_0/wscript
@@ -21,5 +21,8 @@ def build( bld ):
 		includes = './',
 		export_includes = './', 
 		uselib = 'ZLIB BZIP2 RT',
-		cxxflags = [ '-std=c++11', '-Wno-unused-local-typedefs', '-Wno-c++11-long-long', '-Wno-keyword-macro', '-Wno-unused-const-variable' ]
+		# Vendored code we do not maintain: silence its warnings rather than
+		# chase individual -Wno- flags, so that warnings from bgen's own
+		# sources are not lost in the noise.
+		cxxflags = [ '-std=c++11', '-w' ]
 	)

--- a/3rd_party/sqlite3/wscript
+++ b/3rd_party/sqlite3/wscript
@@ -8,7 +8,8 @@ def build( bld ):
 		source = sources,
 		features = [ 'c' ],
 		includes = './',
-		cflags = '-fPIC',
+		# Vendored code we do not maintain; see the note in ../boost_1_55_0/wscript.
+		cflags = [ '-fPIC', '-w' ],
 		defines = 'SQLITE_ENABLE_COLUMN_METADATA SQLITE_ENABLE_STAT4 SQLITE_MAX_EXPR_DEPTH=10000 SQLITE_USE_URI=1',
 		#uselib = 'DL',
 		export_includes = './'

--- a/3rd_party/zstd-1.1.0/wscript
+++ b/3rd_party/zstd-1.1.0/wscript
@@ -18,7 +18,8 @@ def build( bld ):
 		name = 'zstd',
 		target = 'zstd',
 		source = sources,
-		cflags = '-fPIC',
+		# Vendored code we do not maintain; see the note in ../boost_1_55_0/wscript.
+		cflags = [ '-fPIC', '-w' ],
 		includes = [ 'lib', 'lib/common', 'lib/compress', 'lib/decompress' ],
 		export_includes = 'lib/'
 	)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ this tree carries on top of it.
 
 ## Build
 
-```
+```bash
 ./waf configure
 ./waf
 ```
@@ -19,11 +19,11 @@ Outputs land in `build/`. A full build needs a C++11 compiler and zlib headers
 
 Run both suites after changing code.
 
-```
+```bash
 ./build/test/unit/test_bgen            # C++ unit tests
 ```
 
-```
+```bash
 pip install '.[test]'
 pytest                                 # launcher, packaging, bgenix smoke tests
 pytest -m slow                         # also builds a wheel and an sdist and
@@ -32,7 +32,7 @@ pytest -m slow                         # also builds a wheel and an sdist and
 
 A quick end-to-end check of the tool itself:
 
-```
+```bash
 ./build/apps/bgenix -g example/example.16bits.bgen -list
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Working in this repository
+
+This is a mirror of the upstream BGEN reference implementation, plus the
+packaging that publishes its `bgenix` tool to PyPI. Upstream lives in a Fossil
+repository at <https://enkre.net/cgi-bin/code/bgen>; see `PATCHES.md` for what
+this tree carries on top of it.
+
+## Build
+
+```
+./waf configure
+./waf
+```
+
+Outputs land in `build/`. A full build needs a C++11 compiler and zlib headers
+(`apt install g++ zlib1g-dev`).
+
+## Tests
+
+Run both suites after changing code.
+
+```
+./build/test/unit/test_bgen            # C++ unit tests
+```
+
+```
+pip install '.[test]'
+pytest                                 # launcher, packaging, bgenix smoke tests
+pytest -m slow                         # also builds a wheel and an sdist and
+                                       # installs each into a scratch virtualenv
+```
+
+A quick end-to-end check of the tool itself:
+
+```
+./build/apps/bgenix -g example/example.16bits.bgen -list
+```
+
+## Layout
+
+| path | what it is |
+| --- | --- |
+| `src/`, `genfile/`, `db/`, `appcontext/` | the BGEN library (upstream C++) |
+| `apps/` | `bgenix`, `cat-bgen`, `edit-bgen` |
+| `3rd_party/` | vendored boost, sqlite3 and zstd; their warnings are silenced |
+| `bgenix/`, `setup.py`, `pyproject.toml` | the PyPI packaging |
+| `tests/` | pytest suite for the packaging layer |
+| `scripts/` | the upstream version watcher |
+
+## Conventions
+
+- The C++ sources are indented with **tabs** and follow upstream's spacing
+  style (`if( x ) {`, a space before the trailing `;`). Match the file you are
+  editing — a patch that converts tabs to spaces turns a one-token change into
+  a whole-line diff against upstream.
+- Keep changes to the C++ minimal and record each one in `PATCHES.md`, so the
+  delta against upstream stays visible.
+- The package version is `<upstream BGEN version>.post<packaging revision>`;
+  the part before `.post` must match `VERSION` in `wscript`.

--- a/PATCHES.md
+++ b/PATCHES.md
@@ -6,10 +6,10 @@ It vendors **BGEN 1.1.7** (`VERSION` in `wscript`) and carries the changes
 below on top of it.
 
 Everything else — `pyproject.toml`, `setup.py`, `MANIFEST.in`, `bgenix/`,
-`tests/`, `scripts/` and `.github/` — is packaging that upstream does not have,
-and is not counted as a patch here.
+`tests/`, `scripts/`, `AGENTS.md` and `.github/` — is packaging and repository
+tooling that upstream does not have, and is not counted as a patch here.
 
-The PyPI version records both parts: `1.1.7.post1` is the first packaging of
+The PyPI version records both parts: `1.1.7.post2` is the second packaging of
 upstream 1.1.7.  Bump the `.postN` when this file changes without an upstream
 version change.
 
@@ -24,8 +24,42 @@ Commit `e327b0a`.
 +std::streampos origin = m_stream->tellg() ;
 ```
 
-`streampos` is declared in `<ios>` at namespace scope; it is not a member of
-`std::ios`, and stricter compilers reject the qualified form, so upstream 1.1.7
-does not build with them.
+`streampos` was a member typedef of `std::ios_base`, deprecated in C++11 and
+removed in C++17, so upstream 1.1.7 does not build with a compiler defaulting
+to C++17 or newer. The namespace-scope `std::streampos` from `<iosfwd>` is the
+same type and is valid back to C++98.
 
 Not yet submitted upstream.
+
+### Warning fixes
+
+Upstream 1.1.7 emits 45 warnings under `-Wall -pedantic` with GCC 13, 23 of
+them in BGEN's own sources. The changes below clear all 23. Each is a change
+of type or spelling only: `bgen_to_vcf` produces byte-identical output for all
+68 files in `example/` before and after, and the unit tests are unaffected.
+
+* `genfile/include/genfile/bgen/bgen.hpp` — spell the allele count
+  `uint32_t( pack.numberOfAlleles )` in the phased-parsing path, matching the
+  existing idiom a few lines above. `numberOfAlleles` is a `uint16_t`, so
+  `numberOfAlleles - 1` promoted to `int` and was then converted straight back
+  to unsigned by the comparison; the cast makes explicit what was already
+  happening. Accounts for 18 of the 23 warnings, all from this one site
+  instantiated across translation units.
+* `src/View.cpp` — compare `m_stream->gcount()` (a signed `std::streamsize`)
+  with a `std::size_t` explicitly.
+* `apps/bgenix.cpp` — declare `valueSize` as `std::size_t`, since it is only
+  ever compared against `std::string::size()`.
+* `test/unit/test_variant_data_block.cpp` — catch `BGenError const&` rather
+  than by value in `REQUIRE_THROWS_AS`, which was slicing a polymorphic type.
+
+Not yet submitted upstream.
+
+### `3rd_party/*/wscript` — silence warnings from vendored code
+
+boost, sqlite3 and zstd are vendored and not maintained here, so their targets
+build with `-w`. This is build configuration rather than a source change, but
+it is a deviation from upstream and is recorded for that reason.
+
+The remaining 11 warnings in a clean build come from boost headers included by
+BGEN's own translation units, which a flag on the boost target cannot reach;
+building those includes with `-isystem` would clear them.

--- a/apps/bgenix.cpp
+++ b/apps/bgenix.cpp
@@ -919,7 +919,7 @@ private:
 			case 4: dps = 3; break ;
 			case 8: dps = 4; break ;
 		}
-		int const valueSize = 3 + 3 + 3*(dps+((dps>0)?2:1)) ;
+		std::size_t const valueSize = 3 + 3 + 3*(dps+((dps>0)?2:1)) ;
 		std::size_t const numberOfDistinctProbs = 1 << bits ;
 		uint16_t const maxProb = numberOfDistinctProbs - 1 ;
 

--- a/genfile/include/genfile/bgen/bgen.hpp
+++ b/genfile/include/genfile/bgen/bgen.hpp
@@ -1258,11 +1258,11 @@ namespace genfile {
 							// Consume values and interpret them.
 							double sum = 0.0 ;
 							uint32_t reportedValueCount = 0 ;
-							if( !valueConsumer.check( ploidy * (pack.numberOfAlleles-1) )) {
+							if( !valueConsumer.check( ploidy * (uint32_t( pack.numberOfAlleles )-1) )) {
 								throw BGenError() ;
 							}
 							for( uint32_t hap = 0; hap < ploidy; ++hap ) {
-								for( uint32_t allele = 0; allele < (pack.numberOfAlleles-1); ++allele ) {
+								for( uint32_t allele = 0; allele < (uint32_t( pack.numberOfAlleles )-1); ++allele ) {
 									double const value = valueConsumer.next() ;
 									switch( sample_status ) {
 										case eIgnore: break ;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "bgenix"
 # Debian's 1.1.7-1.  The part before '.post' must match VERSION in ./wscript;
 # tests/test_packaging.py enforces that.  See PATCHES.md for what this tree
 # carries on top of upstream.
-version = "1.1.7.post1"
+version = "1.1.7.post2"
 description = "The bgenix BGEN indexing tool, installable with pip"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/View.cpp
+++ b/src/View.cpp
@@ -209,7 +209,7 @@ namespace genfile {
 			// read data up to first data block.
 			m_postheader_data.resize( m_offset+4 - m_stream->tellg() ) ;
 			m_stream->read( reinterpret_cast< char* >( &m_postheader_data[0] ), m_postheader_data.size() ) ;
-			if( m_stream->gcount() != m_postheader_data.size() ) {
+			if( std::size_t( m_stream->gcount() ) != m_postheader_data.size() ) {
 				throw std::invalid_argument(
 					(
 						boost::format(

--- a/test/unit/test_variant_data_block.cpp
+++ b/test/unit/test_variant_data_block.cpp
@@ -62,7 +62,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 				writer.set_number_of_entries( 3, 3, genfile::ePerUnorderedGenotype, genfile::eProbability ) ;
 				for( std::size_t k = 0; k < 3; ++k ) {
 					if( k == g ) {
-						REQUIRE_THROWS_AS( writer.set_value( k, 1.0 + error + 2 * epsilon ), genfile::bgen::BGenError ) ;
+						REQUIRE_THROWS_AS( writer.set_value( k, 1.0 + error + 2 * epsilon ), genfile::bgen::BGenError const& ) ;
 						break ;
 					} else {
 						REQUIRE_NOTHROW( writer.set_value( k, 0 ) ) ;
@@ -105,7 +105,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 						REQUIRE_NOTHROW( writer.set_value( k, v ) ) ;
 					} else {
 						// last value will throw.
-						REQUIRE_THROWS_AS(  writer.set_value( k, v ), genfile::bgen::BGenError ) ;
+						REQUIRE_THROWS_AS(  writer.set_value( k, v ), genfile::bgen::BGenError const& ) ;
 					}
 				}
 			}
@@ -121,7 +121,7 @@ TEST_CASE( "Test probability bound", "[bgen][biallelic][unphased]" ) {
 						REQUIRE_NOTHROW( writer.set_value( k, v ) ) ;
 					} else {
 						// last value will throw
-						REQUIRE_THROWS_AS( writer.set_value( k, v ), genfile::bgen::BGenError ) ;
+						REQUIRE_THROWS_AS( writer.set_value( k, v ), genfile::bgen::BGenError const& ) ;
 					}
 				}
 			}


### PR DESCRIPTION
Revives the work from #3 (and its duplicate #2), re-indented and verified.

Upstream 1.1.7 emits 45 warnings under `-Wall -pedantic` with GCC 13, 23 of them
in BGEN's own sources, which buries anything new in the noise.

| file | before | after |
| --- | --- | --- |
| `genfile/include/genfile/bgen/bgen.hpp` | 18 | 0 |
| `test/unit/test_variant_data_block.cpp` | 3 | 0 |
| `src/View.cpp` | 1 | 0 |
| `apps/bgenix.cpp` | 1 | 0 |
| vendored boost / sqlite3 / zstd | 22 | 11 |

## Changes

- **`bgen.hpp`** — spell the allele count `uint32_t( pack.numberOfAlleles )` in
  the phased-parsing path, matching the idiom already used a few lines above.
  `numberOfAlleles` is a `uint16_t`, so `numberOfAlleles - 1` promoted to `int`
  and the comparison converted it straight back to unsigned; the cast makes
  explicit what was already happening. This single site accounts for 18 of the
  23 warnings, instantiated across translation units.
- **`View.cpp`** — compare `gcount()`, a signed `std::streamsize`, with a
  `std::size_t` explicitly.
- **`bgenix.cpp`** — `valueSize` is only ever compared against
  `std::string::size()`, so declare it `std::size_t`.
- **`test_variant_data_block.cpp`** — catch `BGenError const&` rather than by
  value in `REQUIRE_THROWS_AS`, which was slicing a polymorphic type.
- **`3rd_party/*/wscript`** — build the vendored libraries with `-w` instead of
  chasing individual `-Wno-` flags for code we do not maintain.

## Verification

Every change is a type or spelling change, so this should be invisible at
runtime — and is:

- `bgen_to_vcf` produces **byte-identical output for all 68 files in
  `example/`**, comparing a build of `main` against this branch.
- `bgenix -list` output is identical for `example.16bits.bgen`,
  `haplotypes.bgen` and `complex.bgen`, the last two covering the phased and
  multiallelic paths that the `bgen.hpp` change touches.
- Unit tests unchanged at 1,950,006 assertions; the Python suite passes.

## Notes

- The hunks on #3 were space-indented into tab-indented files, so they read as
  whole-line rewrites. These are re-indented with tabs, leaving a diff that
  shows the tokens that actually changed.
- `AGENTS.md` is rewritten rather than restored — the version on #3 predated the
  Python packaging and pytest suite.
- The 11 remaining warnings are boost headers included by our own translation
  units, which a flag on the boost target cannot reach. Building those includes
  with `-isystem` would clear them; that is a larger change to how include paths
  propagate, so it is left out here.
- Version goes to `1.1.7.post2` and `PATCHES.md` records the new deltas, per the
  scheme in the README. Nothing publishes until a `v1.1.7.post2` tag is pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JBPj5da6i7reenMxoSdyjW

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of probability data for variants with more than two alleles.
  * Fixed compatibility issues with modern C++ compilers.
  * Improved validation of malformed data and exception handling in tests.

* **Build Improvements**
  * Reduced warning noise from bundled third-party components.

* **Documentation**
  * Added repository build, testing, layout, and contribution guidance.
  * Updated patch notes and released version metadata to 1.1.7.post2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->